### PR TITLE
fix: blamer.nvim を削除し gitsigns の current_line_blame に移行

### DIFF
--- a/.config/nvim/lua/ansanloms/plugins.lua
+++ b/.config/nvim/lua/ansanloms/plugins.lua
@@ -20,12 +20,6 @@ require("lazy").setup({
   { "vim-jp/vimdoc-ja" },
   { "vim-denops/denops.vim" },
   {
-    "APZelos/blamer.nvim",
-    config = function()
-      vim.g.blamer_enabled = true
-    end,
-  },
-  {
     "kevinhwang91/nvim-hlslens",
     config = function()
       require("hlslens").setup()
@@ -316,7 +310,14 @@ require("lazy").setup({
   {
     "lewis6991/gitsigns.nvim",
     config = function()
-      require("gitsigns").setup()
+      require("gitsigns").setup({
+        current_line_blame = true,
+        current_line_blame_opts = {
+          delay = 1000,
+          virt_text_pos = "eol",
+        },
+        current_line_blame_formatter = "   <author>, <author_time:%Y/%m/%d %H:%M> - <summary>",
+      })
     end,
   },
   {


### PR DESCRIPTION
blamer.nvim の blamer#GetMessages が git blame の stderr を拾わず、 stdout が空のときに E684 / E116 を BufEnter のたびに出していた。
git 管理外ディレクトリのファイルを開くと毎回発生する。
プラグインは 2023-09 を最後にメンテが止まっているため、導入済みの
gitsigns.nvim の current_line_blame で行末 blame 表示を代替する。