### PR TITLE
feat: statusline に作業中の worktree のブランチを表示

### DIFF
--- a/.claude/scripts/.gitignore
+++ b/.claude/scripts/.gitignore
@@ -1,1 +1,2 @@
 coverage/
+.state/

--- a/.claude/scripts/deno.json
+++ b/.claude/scripts/deno.json
@@ -17,6 +17,7 @@
     "lint": "deno lint && deno fmt --check",
     "fix": "deno lint --fix && deno fmt",
     "notify": "deno run --env-file=.env -A ./notify.ts",
-    "statusline": "deno run -A ./statusline.ts"
+    "statusline": "deno run -A ./statusline.ts",
+    "worktree-state": "deno run -A ./worktree-state.ts"
   }
 }

--- a/.claude/scripts/deno.lock
+++ b/.claude/scripts/deno.lock
@@ -7,8 +7,10 @@
     "jsr:@std/internal@^1.0.12": "1.0.14",
     "jsr:@std/internal@^1.0.14": "1.0.14",
     "jsr:@std/path@1.1.3": "1.1.3",
+    "jsr:@std/path@1.1.4": "1.1.4",
     "jsr:@std/path@1.1.5": "1.1.5",
-    "npm:@anthropic-ai/claude-agent-sdk@0.3.181": "0.3.181_@anthropic-ai+sdk@0.104.2__zod@4.4.3_@modelcontextprotocol+sdk@1.29.0__zod@4.4.3_zod@4.4.3"
+    "npm:@anthropic-ai/claude-agent-sdk@0.3.181": "0.3.181_@anthropic-ai+sdk@0.104.2__zod@4.4.3_@modelcontextprotocol+sdk@1.29.0__zod@4.4.3_zod@4.4.3",
+    "npm:xmlbuilder2@4.0.3": "4.0.3"
   },
   "jsr": {
     "@aireone/deno-lint-curly@0.2.0": {
@@ -28,6 +30,12 @@
     },
     "@std/path@1.1.3": {
       "integrity": "b015962d82a5e6daea980c32b82d2c40142149639968549c649031a230b1afb3",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/path@1.1.4": {
+      "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
         "jsr:@std/internal@^1.0.12"
       ]
@@ -141,6 +149,30 @@
         "zod-to-json-schema"
       ]
     },
+    "@oozcitak/dom@2.0.2": {
+      "integrity": "sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w==",
+      "dependencies": [
+        "@oozcitak/infra",
+        "@oozcitak/url",
+        "@oozcitak/util"
+      ]
+    },
+    "@oozcitak/infra@2.0.2": {
+      "integrity": "sha512-2g+E7hoE2dgCz/APPOEK5s3rMhJvNxSMBrP+U+j1OWsIbtSpWxxlUjq1lU8RIsFJNYv7NMlnVsCuHcUzJW+8vA==",
+      "dependencies": [
+        "@oozcitak/util"
+      ]
+    },
+    "@oozcitak/url@3.0.0": {
+      "integrity": "sha512-ZKfET8Ak1wsLAiLWNfFkZc/BraDccuTJKR6svTYc7sVjbR+Iu0vtXdiDMY4o6jaFl5TW2TlS7jbLl4VovtAJWQ==",
+      "dependencies": [
+        "@oozcitak/infra",
+        "@oozcitak/util"
+      ]
+    },
+    "@oozcitak/util@10.0.0": {
+      "integrity": "sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA=="
+    },
     "@stablelib/base64@1.0.1": {
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="
     },
@@ -168,6 +200,9 @@
         "json-schema-traverse",
         "require-from-string"
       ]
+    },
+    "argparse@2.0.1": {
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "body-parser@2.3.0": {
       "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
@@ -420,6 +455,13 @@
     "jose@6.2.3": {
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="
     },
+    "js-yaml@4.2.0": {
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dependencies": [
+        "argparse"
+      ],
+      "bin": true
+    },
     "json-schema-to-ts@3.1.1": {
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "dependencies": [
@@ -641,6 +683,15 @@
     "wrappy@1.0.2": {
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
+    "xmlbuilder2@4.0.3": {
+      "integrity": "sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA==",
+      "dependencies": [
+        "@oozcitak/dom",
+        "@oozcitak/infra",
+        "@oozcitak/util",
+        "js-yaml"
+      ]
+    },
     "zod-to-json-schema@3.25.2_zod@4.4.3": {
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "dependencies": [
@@ -652,6 +703,7 @@
     }
   },
   "remote": {
+    "https://cdn.jsdelivr.net/gh/ansanloms/wsl-notify@0.0.8/notifier.ts": "a35badcd6b1c72cd70ffbecc28268832258c08cfd43b9f775694111a8de1dbe8",
     "https://cdn.jsdelivr.net/gh/ansanloms/wsl-notify@0.0.8/socket.ts": "c08b0f8605f4c807f2a9c1b9152b12211f4eb56c3f86a67716be059a4b167aed"
   },
   "workspace": {

--- a/.claude/scripts/statusline.ts
+++ b/.claude/scripts/statusline.ts
@@ -7,6 +7,7 @@ import {
   type ProgressBarColorScheme,
 } from "./utils/common.ts";
 import * as git from "./utils/git.ts";
+import { readWorktree } from "./utils/worktree.ts";
 import type { StatusLineInput, StatusLineRateLimitWindow } from "./types.ts";
 
 const getDir = async (input: StatusLineInput) => {
@@ -53,6 +54,20 @@ const getTokens = (input: StatusLineInput) => {
     (input.context_window.current_usage?.cache_read_input_tokens ?? 0);
 };
 
+const resolveWorktreeBranch = async (
+  sessionId: string,
+): Promise<string | null> => {
+  const root = await readWorktree(sessionId);
+  if (root === null) {
+    return null;
+  }
+  const live = await git.linkedWorktreeRoot(root);
+  if (live === null) {
+    return null;
+  }
+  return (await git.branch(live)) || path.basename(live);
+};
+
 try {
   const input = await getInput<StatusLineInput>();
 
@@ -61,13 +76,18 @@ try {
   const cost = input.cost.total_cost_usd;
   const tokens = getTokens(input);
   const pct = Math.floor(input.context_window.used_percentage ?? 0);
+  const worktreeBranch = await resolveWorktreeBranch(input.session_id);
 
+  const line1: [string, string][] = [
+    ["󰚩", model],
+    ["", dir],
+    ["", `$${cost.toLocaleString()}`],
+  ];
+  if (worktreeBranch !== null) {
+    line1.splice(1, 0, ["\uE0A0", worktreeBranch]);
+  }
   console.log(
-    [
-      ["󰚩", model],
-      ["", dir],
-      ["", `$${cost.toLocaleString()}`],
-    ].map(([icon, label]) => `${icon}  ${label}`).join(" | "),
+    line1.map(([icon, label]) => `${icon}  ${label}`).join(" | "),
   );
   console.log(
     buildInlineProgressBar(

--- a/.claude/scripts/types.ts
+++ b/.claude/scripts/types.ts
@@ -182,3 +182,28 @@ export interface StatusLineSettings {
   /** Horizontal padding. Set to 0 to let status line go to edge. */
   padding?: number;
 }
+
+/**
+ * PostToolUse hook 入力のうち worktree-state が参照する部分集合。
+ */
+export interface PostToolUseHookInput {
+  hook_event_name: "PostToolUse";
+  session_id: string;
+  cwd: string;
+  tool_name: string;
+  tool_input: Record<string, unknown>;
+}
+
+/**
+ * SessionEnd hook 入力のうち worktree-state が参照する部分集合。
+ */
+export interface SessionEndHookInput {
+  hook_event_name: "SessionEnd";
+  session_id: string;
+  cwd: string;
+}
+
+/** worktree-state スクリプトが受け取る hook 入力。 */
+export type WorktreeStateHookInput =
+  | PostToolUseHookInput
+  | SessionEndHookInput;

--- a/.claude/scripts/utils/git.ts
+++ b/.claude/scripts/utils/git.ts
@@ -69,3 +69,55 @@ export const commonDir = async (filepath: string): Promise<string> => {
 export const mainRoot = async (filepath: string): Promise<string> => {
   return path.dirname(await commonDir(filepath));
 };
+
+/**
+ * 指定ファイル/ディレクトリが linked worktree 内にあるなら、その worktree の
+ * ルートパスを返す。メイン worktree 内・git 管理外・パスが存在しない場合は
+ * null を返す。toplevel と common-dir を 1 回の rev-parse でまとめて取得する。
+ */
+export const linkedWorktreeRoot = async (
+  filepath: string,
+): Promise<string | null> => {
+  let output: Deno.CommandOutput;
+  try {
+    output = await git(filepath, [
+      "rev-parse",
+      "--show-toplevel",
+      "--git-common-dir",
+    ]);
+  } catch {
+    // filepath が存在しない等で git の実行基点を解決できない場合。
+    return null;
+  }
+  if (output.code !== 0) {
+    return null;
+  }
+
+  // rev-parse はオプション順に値を出力する。1 行目が toplevel、2 行目が
+  // common-dir。common-dir は相対（メイン worktree では ".git"）で返ることが
+  // あるため、git の実行基点で絶対化する。
+  const lines = new TextDecoder().decode(output.stdout).trim().split("\n");
+  if (lines.length < 2) {
+    return null;
+  }
+  const toplevel = lines[0].trim();
+
+  const base = (await Deno.stat(filepath)).isDirectory
+    ? filepath
+    : path.dirname(filepath);
+  const mainRootPath = path.dirname(path.resolve(base, lines[1].trim()));
+
+  return toplevel !== mainRootPath ? toplevel : null;
+};
+
+/**
+ * 指定ファイル/ディレクトリが属する worktree の現在のブランチ名を返す。
+ * detached HEAD 等でブランチ名が無い場合は空文字を返す。
+ */
+export const branch = async (filepath: string): Promise<string> => {
+  const { code, stdout } = await git(filepath, ["branch", "--show-current"]);
+  if (code !== 0) {
+    return "";
+  }
+  return new TextDecoder().decode(stdout).trim();
+};

--- a/.claude/scripts/utils/worktree.ts
+++ b/.claude/scripts/utils/worktree.ts
@@ -1,0 +1,48 @@
+import * as path from "@std/path";
+
+// セッションごとの「作業中 worktree」を記録する state ディレクトリ。
+// このモジュール（scripts/utils/）からの相対で scripts/.state/worktree/ を指す。
+const stateDir = path.fromFileUrl(
+  new URL("../.state/worktree/", import.meta.url),
+);
+
+const stateFile = (sessionId: string): string =>
+  path.join(stateDir, `${encodeURIComponent(sessionId)}.json`);
+
+/**
+ * セッションが作業中の worktree ルートを記録する。
+ */
+export const recordWorktree = async (
+  sessionId: string,
+  root: string,
+): Promise<void> => {
+  await Deno.mkdir(stateDir, { recursive: true });
+  await Deno.writeTextFile(stateFile(sessionId), JSON.stringify({ root }));
+};
+
+/**
+ * セッションに記録された worktree ルートを返す。未記録・破損時は null。
+ */
+export const readWorktree = async (
+  sessionId: string,
+): Promise<string | null> => {
+  try {
+    const data = JSON.parse(await Deno.readTextFile(stateFile(sessionId))) as {
+      root?: unknown;
+    };
+    return typeof data.root === "string" ? data.root : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * セッションの記録を削除する。無ければ何もしない。
+ */
+export const clearWorktree = async (sessionId: string): Promise<void> => {
+  try {
+    await Deno.remove(stateFile(sessionId));
+  } catch {
+    // 既に無い場合は無視する。
+  }
+};

--- a/.claude/scripts/worktree-state.test.ts
+++ b/.claude/scripts/worktree-state.test.ts
@@ -1,0 +1,58 @@
+import { assertEquals } from "@std/assert";
+import { parseWorktreeAddPath } from "./worktree-state.ts";
+import {
+  clearWorktree,
+  readWorktree,
+  recordWorktree,
+} from "./utils/worktree.ts";
+
+Deno.test("parseWorktreeAddPath: path then new branch flag", () => {
+  assertEquals(
+    parseWorktreeAddPath("git worktree add /base/foo -b feat/foo"),
+    "/base/foo",
+  );
+});
+
+Deno.test("parseWorktreeAddPath: new branch flag then path", () => {
+  assertEquals(
+    parseWorktreeAddPath("git worktree add -b feat/foo /base/foo"),
+    "/base/foo",
+  );
+});
+
+Deno.test("parseWorktreeAddPath: existing branch positional", () => {
+  assertEquals(
+    parseWorktreeAddPath("git worktree add /base/bar existing-branch"),
+    "/base/bar",
+  );
+});
+
+Deno.test("parseWorktreeAddPath: leading -C and value flag", () => {
+  assertEquals(
+    parseWorktreeAddPath("git -C /repo worktree add --quiet /base/baz"),
+    "/base/baz",
+  );
+});
+
+Deno.test("parseWorktreeAddPath: quoted path with space", () => {
+  assertEquals(
+    parseWorktreeAddPath('git worktree add "/base/with space" -b x'),
+    "/base/with space",
+  );
+});
+
+Deno.test("parseWorktreeAddPath: not an add command", () => {
+  assertEquals(parseWorktreeAddPath("git worktree list"), null);
+});
+
+Deno.test("worktree state store round-trip", async () => {
+  const sessionId = `test-${crypto.randomUUID()}`;
+  try {
+    assertEquals(await readWorktree(sessionId), null);
+    await recordWorktree(sessionId, "/some/worktree/root");
+    assertEquals(await readWorktree(sessionId), "/some/worktree/root");
+  } finally {
+    await clearWorktree(sessionId);
+  }
+  assertEquals(await readWorktree(sessionId), null);
+});

--- a/.claude/scripts/worktree-state.ts
+++ b/.claude/scripts/worktree-state.ts
@@ -1,0 +1,86 @@
+import * as path from "@std/path";
+import { getInput } from "./utils/common.ts";
+import * as git from "./utils/git.ts";
+import { clearWorktree, recordWorktree } from "./utils/worktree.ts";
+import type { WorktreeStateHookInput } from "./types.ts";
+
+/**
+ * `git worktree add <path> ...` から作成先 path を best-effort で抜く。
+ * 最初の非フラグ位置引数を path とみなす。抽出できなければ null。
+ */
+export const parseWorktreeAddPath = (command: string): string | null => {
+  const matched = command.match(/\bworktree\s+add\b([^\n]*)/);
+  if (matched === null) {
+    return null;
+  }
+  const tokens = matched[1].match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
+  // 値を取るフラグ。直後のトークンは path ではないのでスキップする。
+  const flagsWithValue = new Set(["-b", "-B", "--reason", "--lock-reason"]);
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (token.startsWith("-")) {
+      if (flagsWithValue.has(token)) {
+        i++;
+      }
+      continue;
+    }
+    return token.replace(/^["']|["']$/g, "");
+  }
+  return null;
+};
+
+/**
+ * 対象パスから linked worktree を解決し、見つかればセッションに記録する。
+ */
+const recordIfWorktree = async (
+  sessionId: string,
+  target: string,
+): Promise<void> => {
+  const root = await git.linkedWorktreeRoot(target);
+  if (root !== null) {
+    await recordWorktree(sessionId, root);
+  }
+};
+
+const main = async (): Promise<void> => {
+  const input = await getInput<WorktreeStateHookInput>();
+
+  if (input.hook_event_name === "SessionEnd") {
+    // セッション終了時に記録を掃除する。
+    await clearWorktree(input.session_id);
+    return;
+  }
+
+  if (input.hook_event_name === "PostToolUse") {
+    const filePath = input.tool_input?.file_path ??
+      input.tool_input?.notebook_path;
+    if (typeof filePath === "string") {
+      // Edit / Write 系: 編集対象ファイルが属する worktree を記録する。
+      await recordIfWorktree(input.session_id, filePath);
+      return;
+    }
+
+    if (input.tool_name === "Bash") {
+      const command = input.tool_input?.command;
+      // `git worktree add` の瞬間を捕捉する（初回編集前・read-only worktree 対策）。
+      if (typeof command === "string" && command.includes("worktree add")) {
+        const added = parseWorktreeAddPath(command);
+        if (added !== null) {
+          await recordIfWorktree(
+            input.session_id,
+            path.resolve(input.cwd, added),
+          );
+        }
+      }
+    }
+  }
+};
+
+if (import.meta.main) {
+  try {
+    await main();
+  } catch {
+    // hook はツール実行を止めない。あらゆる失敗を握り潰す。
+    Deno.exit(0);
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,30 @@
     "defaultMode": "auto"
   },
   "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "deno task --cwd ~/.claude/scripts worktree-state",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "deno task --cwd ~/.claude/scripts worktree-state",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": "",


### PR DESCRIPTION
## 背景

`git worktree add` で worktree を作り、メインの worktree (clone 直下) 側から
編集する運用では、セッションの作業ディレクトリが worktree へ移らない。
そのため statusline の入力 (`workspace.current_dir`) だけでは「今どの worktree で
作業しているか」を判定できない。

## 変更

session_id をキーにした side channel を追加し、このギャップを埋めた。

### worktree-state hook (`worktree-state.ts`)

`PostToolUse` で次を捕捉し、属する worktree のルートを
`.state/worktree/<session_id>.json` へ記録する。

- Edit / Write / MultiEdit / NotebookEdit: `file_path` / `notebook_path`
- Bash の `git worktree add`: 作成先 path (初回編集前・read-only worktree 対策)

worktree 判定はパス規約に依存せず、`git rev-parse --show-toplevel` と
`--git-common-dir` の差分という git の構造で行う (`git.linkedWorktreeRoot`)。

`SessionEnd` でそのセッションの記録を掃除する。

### statusline (`statusline.ts`)

`session_id` で記録を引き、その worktree が今も生存しているかを git で
検証したうえで、ブランチ名を 1 行目のセグメントとして表示する。
worktree が撤去済みなら git 検証が失敗するため、表示は自動で消える。
worktree 外 (メイン) では従来どおりの出力。

### その他

- `utils/worktree.ts`: state ストア (record / read / clear)
- `utils/git.ts`: `linkedWorktreeRoot` / `branch` を追加
- `settings.json`: `PostToolUse` / `SessionEnd` hook を登録
- `deno.json`: `worktree-state` task を追加
- `.gitignore`: 実行時の `.state/` を除外
- `worktree-state.test.ts`: `parseWorktreeAddPath` と state ストアの単体テスト

## 検証

- `deno task lint` / `deno check` / 全テスト (56 件) 通過
- エンドツーエンド: worktree 内ファイルの Edit を hook が捕捉 → statusline に
  ブランチ表示 → SessionEnd で記録削除 → 表示が消えることを確認

## 補足

`PostToolUse` は Bash を含む対象ツールごとに起動するため、worktree-state は
Bash では `worktree add` を含むコマンドのみ処理し、それ以外は即終了する。
hook はあらゆる失敗を握り潰し、ツール実行を止めない。
