### PR TITLE
feat: 通知をイベント種別ごとに整理

### DIFF
--- a/.claude/scripts/deno.json
+++ b/.claude/scripts/deno.json
@@ -5,7 +5,7 @@
     "plugins": ["jsr:@aireone/deno-lint-curly"]
   },
   "imports": {
-    "@anthropic-ai/claude-agent-sdk": "npm:@anthropic-ai/claude-agent-sdk@0.3.181",
+    "@anthropic-ai/claude-agent-sdk": "npm:@anthropic-ai/claude-agent-sdk@0.3.185",
     "@std/assert": "jsr:@std/assert@1.0.19",
     "@std/fmt": "jsr:@std/fmt@1.0.10",
     "@std/path": "jsr:@std/path@1.1.5",

--- a/.claude/scripts/deno.lock
+++ b/.claude/scripts/deno.lock
@@ -8,7 +8,7 @@
     "jsr:@std/internal@^1.0.14": "1.0.14",
     "jsr:@std/path@1.1.3": "1.1.3",
     "jsr:@std/path@1.1.5": "1.1.5",
-    "npm:@anthropic-ai/claude-agent-sdk@0.3.181": "0.3.181_@anthropic-ai+sdk@0.104.2__zod@4.4.3_@modelcontextprotocol+sdk@1.29.0__zod@4.4.3_zod@4.4.3"
+    "npm:@anthropic-ai/claude-agent-sdk@0.3.185": "0.3.185_@anthropic-ai+sdk@0.105.0__zod@4.4.3_@modelcontextprotocol+sdk@1.29.0__zod@4.4.3_zod@4.4.3"
   },
   "jsr": {
     "@aireone/deno-lint-curly@0.2.0": {
@@ -40,48 +40,48 @@
     }
   },
   "npm": {
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.181": {
-      "integrity": "sha512-krU5aV651tfv0IeLXo2m+YYduOdirQ+/ptv4IVXivsrjtBXHrtTTLrOaBEFuRQSLqCAMaTH3cITR+mj6ij4kMA==",
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.185": {
+      "integrity": "sha512-P2Svxx1IFrS9aw4ylJBtcoJrc/OAOVnDs+o05x4TV7HoHUQUcKZ9XhWOGnadyVT0KLyoktgjyjnaK7Zdtc0Ldg==",
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
-    "@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.181": {
-      "integrity": "sha512-kD+eMhGu2GA1/itW1LDYYELTNnQCre5C1RpekdEtQRP1iXWt6qQ+E42RJmMutBGVLGAl1cqRXIxTHXbuOWsecQ==",
+    "@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.185": {
+      "integrity": "sha512-H69m2hIJawzSkCDNO/CPLQCYvDGdlbZdzGTgGF8/IQuB4O81sv8WSAh6TBXwtFXOgEi4HtrUYlxiFDmTHt7hMA==",
       "os": ["darwin"],
       "cpu": ["x64"]
     },
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.181": {
-      "integrity": "sha512-lI39OgTCqKAqTtNF3a6+z4ToS2QKLWQw0oZGSGCMb2k6MrPB2OqyN/JSH6nvKfxLpaQmVTowwpyR4JInHMzobw==",
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.185": {
+      "integrity": "sha512-1GRpKYrg5foomW+qLrxm/k2R/5PEU7RAuEdX65HV6lFMJR3HsGj8qfBq4KCJHTS3r4YdVrFLvPQ/mUqbY6klIA==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.181": {
-      "integrity": "sha512-DgrafZ4bfZN7mPOLraEzraU2A263K9Kg01i3PBSH4Mx5CfTUbJ6IVR1cYgwRCk2c4BwQmS0onnvxfgwAxP0dKg==",
+    "@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.185": {
+      "integrity": "sha512-KtXMCoprGYTSPb/A0/kjrO+PpDJAFbHhDd8rjqA4izU51OYjTDkahsGCcSTFM2jA8krOhPqzx/SNVuAVWmexwA==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.181": {
-      "integrity": "sha512-FNf6QhAZ8/7q9MfFTCEfc0nA6oOSrEyKq3Xv2Jt4iSEViXYuIC25shk4T4EvU8qoLtbS51NCxCdpD7b0zCHvFQ==",
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.185": {
+      "integrity": "sha512-YAky0Oez+YYrlcas/xDiaCm9AUX0z1YwM+pnk+CFxEr/ICmc7MbiFsnEIXFLPHaox9bE5iOzw4LS4b/c1tIJRg==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@anthropic-ai/claude-agent-sdk-linux-x64@0.3.181": {
-      "integrity": "sha512-KKYcN2PKHPUOPKKWsPY1bEEkeVMiOmTRpzIleGlCPsXJLS/QnN6RgNOHIrapRmh0z9uFl24KCP5X1OUMWZqu4Q==",
+    "@anthropic-ai/claude-agent-sdk-linux-x64@0.3.185": {
+      "integrity": "sha512-8U5wu6dNcyzRkwoae0Gu5ZHs6lRSu8CXqd9yrilX3fHR9kKICrm76bLu5q2auuSc/8dx6VL5ZXqSzFKIMp//zw==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.181": {
-      "integrity": "sha512-7plhWEB9/ExlzTMY9SzUy6zSoCrMP4KFBJwfmkt0plxwv8lFJqX/tEH/r4QDQxrMQnR+d6RcbgPH6g3hnu3NMQ==",
+    "@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.185": {
+      "integrity": "sha512-pJEOaCLQQQWSyBeseR/GAn4eEp4WtMDP/o5yPMuuAsNWeoJXM7cY4j/N3KBE6GZofgnYdWEXILF2uw3SjbtINA==",
       "os": ["win32"],
       "cpu": ["arm64"]
     },
-    "@anthropic-ai/claude-agent-sdk-win32-x64@0.3.181": {
-      "integrity": "sha512-CQKaMv5tYBUxtFe1XG2qhnNJrmChXf+nhi5FhbE3GElWeNaXKMOTYqflii3zOT3yhqnrbh7fz1gzhOFwALtCeA==",
+    "@anthropic-ai/claude-agent-sdk-win32-x64@0.3.185": {
+      "integrity": "sha512-/Kf9XneSuIkSHNwrxOVY0XT7RovAEcx5nDASKzku4994cZz54otU5mT2jT6dwevDLEStfgts5x/A4z0AePwVTQ==",
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "@anthropic-ai/claude-agent-sdk@0.3.181_@anthropic-ai+sdk@0.104.2__zod@4.4.3_@modelcontextprotocol+sdk@1.29.0__zod@4.4.3_zod@4.4.3": {
-      "integrity": "sha512-xT2pXqqvCSmTwO5zctIxL4dO9vX7+rKeybvLBuEvUxub8sDyScK8s1dVstxL4ZtHQzOIDUng43qEq/kefNp+aA==",
+    "@anthropic-ai/claude-agent-sdk@0.3.185_@anthropic-ai+sdk@0.105.0__zod@4.4.3_@modelcontextprotocol+sdk@1.29.0__zod@4.4.3_zod@4.4.3": {
+      "integrity": "sha512-UDDd0cInvOufmR88btR/Ursnh71sb5scoutNlRS2L0LBdkt7JEqYJ0jt7DnOYHEVhMx8AAcg0eYgvXztcWUnFA==",
       "dependencies": [
         "@anthropic-ai/sdk",
         "@modelcontextprotocol/sdk",
@@ -98,8 +98,8 @@
         "@anthropic-ai/claude-agent-sdk-win32-x64"
       ]
     },
-    "@anthropic-ai/sdk@0.104.2_zod@4.4.3": {
-      "integrity": "sha512-s1wEVDAtEwkS7Ajgep6PZKJLFqybRkmD3Byz+iVVsSpbDY0gjROXE9aOft6V3PMqynn3NTcycV5whga9tCzmKA==",
+    "@anthropic-ai/sdk@0.105.0_zod@4.4.3": {
+      "integrity": "sha512-sDyu+aM9cE6uZE+HgRjjHRb+qqb87GHZOx+8bE0YlWetdL1YcVLxn8h9ltxGOflyChTe6PMEo50kMQV4cw0hfg==",
       "dependencies": [
         "json-schema-to-ts",
         "standardwebhooks",
@@ -659,7 +659,7 @@
       "jsr:@std/assert@1.0.19",
       "jsr:@std/fmt@1.0.10",
       "jsr:@std/path@1.1.5",
-      "npm:@anthropic-ai/claude-agent-sdk@0.3.181"
+      "npm:@anthropic-ai/claude-agent-sdk@0.3.185"
     ]
   }
 }

--- a/.claude/scripts/notify.ts
+++ b/.claude/scripts/notify.ts
@@ -3,24 +3,26 @@ import { SOCK_PATH } from "@ansanloms/wsl-notify/socket.ts";
 
 import type { HookInput } from "./types.ts";
 import { getInput } from "./utils/common.ts";
-import { getMessage } from "./utils/hook.ts";
+import { buildNotification, type Notification } from "./utils/hook.ts";
 
 const BUFFER_SIZE = 16384; // 16KB
 const __dirname = new URL(".", import.meta.url).pathname;
 
-const getAudioSrc = (eventName: string) => {
-  if (eventName === "Stop") {
-    return "ms-winsoundevent:Notification.Looping.Alarm8";
+/**
+ * 非 ASCII を含む文字列を HTTP ヘッダ値へ載せられる形にする。
+ * fetch のヘッダ値は Latin-1（0-255）しか許さないため、UTF-8 バイト列を
+ * 1 バイト 1 文字へ写す。ntfy サーバは受け取った生バイトを UTF-8 として解釈する。
+ */
+const encodeHeader = (text: string): string => {
+  const bytes = new TextEncoder().encode(text);
+  let out = "";
+  for (const byte of bytes) {
+    out += String.fromCharCode(byte);
   }
-
-  if (eventName === "Notification") {
-    return "ms-winsoundevent:Notification.Looping.Call7";
-  }
-
-  return "ms-winsoundevent:Notification.Looping.Call6";
+  return out;
 };
 
-const notifyNtfy = async (input: HookInput, message: string) => {
+const notifyNtfy = async (notification: Notification) => {
   const url = Deno.env.get("NTFW_URL");
   const token = Deno.env.get("NTFW_TOKEN");
 
@@ -31,12 +33,12 @@ const notifyNtfy = async (input: HookInput, message: string) => {
   try {
     await fetch(url, {
       method: "POST",
-      body: message,
+      body: notification.body,
       headers: {
         Authorization: `Bearer ${token}`,
         Markdown: "yes",
-        Title: `Claude Code (${input.cwd})`,
-        Tags: input.hook_event_name,
+        Title: encodeHeader(notification.title),
+        Tags: notification.tag,
       },
     });
   } catch (error) {
@@ -44,7 +46,7 @@ const notifyNtfy = async (input: HookInput, message: string) => {
   }
 };
 
-const notifyWindows = async (input: HookInput, message: string) => {
+const notifyWindows = async (input: HookInput, notification: Notification) => {
   const conn = await Deno.connect({
     path: SOCK_PATH,
     transport: "unix",
@@ -52,16 +54,16 @@ const notifyWindows = async (input: HookInput, message: string) => {
 
   try {
     const req: NotifyRequest = {
-      title: "Claude Code",
-      message,
-      attribution: `${input.session_id} (${input.hook_event_name})`,
+      title: `${notification.emoji} ${notification.title}`,
+      message: notification.body,
+      attribution: input.cwd,
       image: {
         placement: "appLogoOverride",
         hintCrop: "circle",
         src: `${__dirname}/clawd.jpg`,
       },
       audio: {
-        src: getAudioSrc(input.hook_event_name),
+        src: notification.sound,
       },
       duration: "long",
     };
@@ -77,6 +79,9 @@ const notifyWindows = async (input: HookInput, message: string) => {
 };
 
 const input = await getInput();
-const message = (await getMessage(input)) ?? "";
+const notification = await buildNotification(input);
 
-await Promise.all([notifyNtfy(input, message), notifyWindows(input, message)]);
+await Promise.all([
+  notifyNtfy(notification),
+  notifyWindows(input, notification),
+]);

--- a/.claude/scripts/utils/hook.test.ts
+++ b/.claude/scripts/utils/hook.test.ts
@@ -5,11 +5,14 @@ import type {
   StopHookInput,
 } from "@anthropic-ai/claude-agent-sdk";
 import {
+  buildNotification,
   formatToolInput,
+  getEventDescriptor,
   getLastAssistantMessage,
   getMessage,
   getNotificationMessage,
   getPermissionRequestMessage,
+  getStopFailureMessage,
   getStopMessage,
 } from "./hook.ts";
 
@@ -259,4 +262,70 @@ Deno.test("getMessage: PermissionRequest イベント", async () => {
     await getMessage(input),
     "**Write** の実行許可を求めています\n/tmp/out.ts",
   );
+});
+
+// --- getEventDescriptor ---
+
+Deno.test("getEventDescriptor: 既知イベントは対応する属性を返す", () => {
+  assertEquals(getEventDescriptor("Stop").label, "完了");
+  assertEquals(getEventDescriptor("SubagentStop").label, "サブ完了");
+  assertEquals(getEventDescriptor("StopFailure").label, "失敗");
+  assertEquals(getEventDescriptor("Notification").label, "確認待ち");
+  assertEquals(getEventDescriptor("PermissionRequest").label, "許可待ち");
+});
+
+// --- getStopFailureMessage ---
+
+Deno.test("getStopFailureMessage: error_type があれば種別を含める", () => {
+  const input = {
+    ...baseInput,
+    hook_event_name: "StopFailure",
+    error_type: "rate_limit",
+  } as unknown as Parameters<typeof getStopFailureMessage>[0];
+  assertEquals(
+    getStopFailureMessage(input),
+    "API エラーでターンが終了: rate_limit",
+  );
+});
+
+Deno.test("getStopFailureMessage: error type が無ければ固定文言を返す", () => {
+  const input = {
+    ...baseInput,
+    hook_event_name: "StopFailure",
+  } as unknown as Parameters<typeof getStopFailureMessage>[0];
+  assertEquals(getStopFailureMessage(input), "API エラーでターンが終了");
+});
+
+Deno.test("getEventDescriptor: 未知イベントは既定値を返す", () => {
+  const descriptor = getEventDescriptor("Unknown");
+  assertEquals(descriptor.label, "通知");
+  assertEquals(descriptor.tag, "speech_balloon");
+});
+
+// --- buildNotification ---
+
+Deno.test("buildNotification: タイトルはラベルとプロジェクト名を結合する", async () => {
+  const input: StopHookInput = {
+    ...baseInput,
+    cwd: "/home/user/dev/dotfiles",
+    hook_event_name: "Stop",
+    stop_hook_active: false,
+    last_assistant_message: "作業完了",
+  };
+  const notification = await buildNotification(input);
+  assertEquals(notification.title, "完了 | dotfiles");
+  assertEquals(notification.body, "作業完了");
+  assertEquals(notification.tag, "white_check_mark");
+  assertEquals(notification.emoji, "✅");
+});
+
+Deno.test("buildNotification: 本文はメッセージをそのまま渡す", async () => {
+  const input: StopHookInput = {
+    ...baseInput,
+    hook_event_name: "Stop",
+    stop_hook_active: false,
+    last_assistant_message: "x".repeat(200),
+  };
+  const notification = await buildNotification(input);
+  assertEquals(notification.body, "x".repeat(200));
 });

--- a/.claude/scripts/utils/hook.ts
+++ b/.claude/scripts/utils/hook.ts
@@ -1,3 +1,4 @@
+import { basename } from "@std/path";
 import type {
   HookInput,
   NotificationHookInput,
@@ -126,4 +127,134 @@ export const getMessage = async (input: HookInput) => {
     default:
       return await getLastAssistantMessage(input.transcript_path);
   }
+};
+
+/**
+ * hook イベント種別ごとの表示属性。
+ * 「どのラベル・どの絵文字・どの音か」をこの 1 箇所で定義する。
+ */
+export interface EventDescriptor {
+  /** 通知タイトルの先頭に出す、一目で種別が分かるラベル。 */
+  label: string;
+
+  /** ntfy の Tags に渡す絵文字キーワード（受信側でアイコンに変換される）。 */
+  tag: string;
+
+  /**
+   * 絵文字リテラル。Windows トーストは Tags のようなキーワード変換を持たないため、
+   * タイトル先頭へ直接前置するのに使う。`tag` と同じ意味の絵文字を指す。
+   */
+  emoji: string;
+
+  /** Windows トーストの通知音（ms-winsoundevent URI）。 */
+  sound: string;
+}
+
+/**
+ * イベント種別 → 表示属性の対応表。
+ * 新しいイベントを通知対象に加える場合や、ラベル・音を変える場合はここを編集する。
+ */
+const eventDescriptors: Record<string, EventDescriptor> = {
+  Stop: {
+    label: "完了",
+    tag: "white_check_mark",
+    emoji: "✅",
+    sound: "ms-winsoundevent:Notification.Looping.Alarm8",
+  },
+  SubagentStop: {
+    label: "サブ完了",
+    tag: "ballot_box_with_check",
+    emoji: "☑️",
+    sound: "ms-winsoundevent:Notification.Looping.Call5",
+  },
+  StopFailure: {
+    label: "失敗",
+    tag: "rotating_light",
+    emoji: "🚨",
+    sound: "ms-winsoundevent:Notification.Looping.Alarm2",
+  },
+  Notification: {
+    label: "確認待ち",
+    tag: "bell",
+    emoji: "🔔",
+    sound: "ms-winsoundevent:Notification.Looping.Call7",
+  },
+  PermissionRequest: {
+    label: "許可待ち",
+    tag: "warning",
+    emoji: "⚠️",
+    sound: "ms-winsoundevent:Notification.Looping.Call6",
+  },
+};
+
+/** 対応表にないイベント用のフォールバック属性。 */
+const defaultDescriptor: EventDescriptor = {
+  label: "通知",
+  tag: "speech_balloon",
+  emoji: "💬",
+  sound: "ms-winsoundevent:Notification.Looping.Call6",
+};
+
+/**
+ * イベント名に対応する表示属性を返す。未知のイベントは既定値を返す。
+ */
+export const getEventDescriptor = (eventName: string): EventDescriptor =>
+  eventDescriptors[eventName] ?? defaultDescriptor;
+
+/**
+ * StopFailure hook 用メッセージを取得する。
+ * ターンが API エラーで終了したことと、判明すればその error type を返す。
+ * error type のフィールド名は公式に確定していないため、候補を順に探し、
+ * いずれも無ければ種別なしの固定文言にフォールバックする。
+ */
+export const getStopFailureMessage = (input: HookInput): string => {
+  const record = input as Record<string, unknown>;
+  const errorType = record.error_type ?? record.error ?? record.reason;
+  return typeof errorType === "string" && errorType
+    ? `API エラーでターンが終了: ${errorType}`
+    : "API エラーでターンが終了";
+};
+
+/**
+ * 送信経路に依存しない通知 1 件分の構成要素。
+ * 各経路（ntfy / Windows トースト）はこれを自分の形式へ流し込む。
+ */
+export interface Notification {
+  /** タイトル。「ラベル | プロジェクト名」形式（絵文字は含まない）。 */
+  title: string;
+
+  /** 本文。イベント別メッセージそのまま。 */
+  body: string;
+
+  /** ntfy の Tags に渡す絵文字キーワード。 */
+  tag: string;
+
+  /** タイトル先頭へ前置する絵文字リテラル（Windows トースト用）。 */
+  emoji: string;
+
+  /** Windows トーストの通知音。 */
+  sound: string;
+}
+
+/**
+ * hook 入力から、種別ラベル付きで読みやすい通知 1 件を組み立てる。
+ * - タイトル: 「<ラベル> | <プロジェクト名>」（プロジェクト名は cwd の basename）
+ * - 本文: イベント別メッセージそのまま
+ */
+export const buildNotification = async (
+  input: HookInput,
+): Promise<Notification> => {
+  const descriptor = getEventDescriptor(input.hook_event_name);
+  const project = basename(input.cwd);
+  const message = (input.hook_event_name as string) === "StopFailure"
+    ? getStopFailureMessage(input)
+    : (await getMessage(input)) ?? "";
+
+  return {
+    title: `${descriptor.label} | ${project}`,
+    body: message,
+    tag: descriptor.tag,
+    emoji: descriptor.emoji,
+    sound: descriptor.sound,
+  };
 };

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,6 +34,30 @@
         ]
       }
     ],
+    "SubagentStop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "deno task --cwd ~/.claude/scripts notify",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "deno task --cwd ~/.claude/scripts notify",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "Notification": [
       {
         "matcher": "^(?!permission_prompt).*",


### PR DESCRIPTION
## 概要

Claude Code の通知系を、受け取る通知の中身が一目で分かるように整理した。
hook イベント種別ごとの表示属性（ラベル・ntfy Tags・絵文字・通知音）を
`utils/hook.ts` の 1 テーブルへ集約し、種別の判別を音やイベント名に
頼らず行えるようにした。

## 変更点

- 通知タイトルを「ラベル | プロジェクト名」形式へ統一（プロジェクト名は cwd の basename）。
- 通知対象イベントを拡張: 従来の Stop / Notification / PermissionRequest に加え、
  **SubagentStop（サブ完了）** と **StopFailure（失敗）** を追加。`settings.json` に hook を登録。
- StopFailure は API エラーで終了した旨と、判明すれば error type を本文に出す。
  error type のフィールド名は公式に未確定のため候補（error_type → error → reason）を順に探索する。
- Windows トーストはタイトル先頭に絵文字リテラルを前置（Tags のようなキーワード変換が無いため）。
- ntfy の Title ヘッダは Latin-1 制約を回避するため UTF-8 バイトをエンコードして送信。
- 依存 `@anthropic-ai/claude-agent-sdk` を 0.3.181 → 0.3.185 へ更新（別コミット）。

## イベント別の対応

| イベント | ラベル | 絵文字 | 音 |
| --- | --- | --- | --- |
| Stop | 完了 | ✅ | Alarm8 |
| SubagentStop | サブ完了 | ☑️ | Call5 |
| StopFailure | 失敗 | 🚨 | Alarm2 |
| Notification | 確認待ち | 🔔 | Call7 |
| PermissionRequest | 許可待ち | ⚠️ | Call6 |

## 検証

- `deno check` / `deno lint` / `deno fmt` 通過、テスト 55 件全通過。
- Stop / PermissionRequest / StopFailure の各通知を `notify.ts` へ実入力を流して実送信し、
  ntfy・Windows トーストの双方で受信を確認（exit 0）。

## 注意点

- StopFailure の error type フィールド名は未検証。実際の API エラー発生時の payload で
  名前が異なる場合、本文は種別なしの「API エラーでターンが終了」になる。
- SubagentStop はサブエージェント 1 体ごとに発火するため、多エージェント運用では通知が増える。

🤖 Generated with [Claude Code](https://claude.com/claude-code)