### PR TITLE
ci: 定期実行ワークフローの失敗を修正

### DIFF
--- a/.github/workflows/nix-bump.yml
+++ b/.github/workflows/nix-bump.yml
@@ -17,11 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # ローカルと同じ Determinate Nix を使い、nix のバージョン差による挙動ずれを防ぐ。
+      # (flakes / nix-command は Determinate Nix では既定で有効)
       - name: Install Nix
-        uses: cachix/install-nix-action@v30
+        uses: DeterminateSystems/nix-installer-action@v22
         with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+          determinate: true
 
       - name: Setup Deno
         uses: denoland/setup-deno@v2
@@ -29,6 +30,9 @@ jobs:
           deno-version: v2.x
 
       - name: Bump self-built packages
+        # bump:sonarqube-cli が gh api で最新タグを引くため GH_TOKEN が必要。
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: deno task bump
 
       - name: Stage and detect changes

--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -17,11 +17,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # ローカルと同じ Determinate Nix を使い、nix のバージョン差による挙動ずれを防ぐ。
+      # 旧: cachix/install-nix-action@v30 (Nix 2.24.9) は deno task upgrade の
+      # 相対 path: flake ref (path:.config/nix) を解決できず失敗していた。
+      # (flakes / nix-command は Determinate Nix では既定で有効)
       - name: Install Nix
-        uses: cachix/install-nix-action@v30
+        uses: DeterminateSystems/nix-installer-action@v22
         with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+          determinate: true
 
       - name: Setup Deno
         uses: denoland/setup-deno@v2


### PR DESCRIPTION
## 概要

スケジュール実行の `nix flake update` / `nix bump` が数週連続で失敗していたのを修正する。

## 原因と対応

### nix flake update(6/22 以降 3 週連続失敗)

`0d0e892` で `deno task upgrade` の flake 指定を `path:.config/nix`(相対 `path:` ref)へ変更したが、CI の `cachix/install-nix-action@v30` が入れる Nix 2.24.9 はこれを解決できない。

```
error: cannot fetch input 'path:.config/nix' because it uses a relative path
```

ローカル(Determinate Nix 3.21.2 / Nix 2.34.7)では動作するため、CI とのバージョン差が原因。ローカルと同じ Determinate Nix を入れる `DeterminateSystems/nix-installer-action@v22`(`determinate: true`)へ切り替える。flakes / nix-command は既定で有効のため `extra_nix_config` は不要。

### nix bump(6/29 以降 2 週連続失敗)

`ccb08d1` で追加した `bump:sonarqube-cli` が `gh api` で最新タグを取得するが、GitHub Actions 上の gh CLI は `GH_TOKEN` が必須。bump ステップに `GH_TOKEN: ${{ github.token }}` を追加する。

nix bump 側の installer も同じものへ揃え、upgrade スクリプトが使う `nix flake prefetch` / `nix store prefetch-file` の挙動ずれを防ぐ。

## 確認

- YAML 構文チェック済み
- マージ後、`workflow_dispatch` で両ワークフローの手動実行により動作確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)