### PR TITLE
ci: 自動 push 前に remote の進みを取り込む

### DIFF
--- a/.github/workflows/nix-bump.yml
+++ b/.github/workflows/nix-bump.yml
@@ -56,4 +56,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "chore: 自前 nix パッケージのバージョンを更新"
+          # 並行するワークフローが先に main へ push していると non-fast-forward で
+          # 弾かれるため、remote の進みを取り込んでから push する。
+          git fetch origin main
+          git rebase FETCH_HEAD
           git push origin HEAD:main

--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -55,4 +55,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "chore: flake input を更新"
+          # 並行するワークフローが先に main へ push していると non-fast-forward で
+          # 弾かれるため、remote の進みを取り込んでから push する。
+          git fetch origin main
+          git rebase FETCH_HEAD
           git push origin HEAD:main


### PR DESCRIPTION
## 概要

`nix bump` / `nix flake update` の並行実行時に、後から push する側が non-fast-forward で拒否される問題への対策。`workflow_dispatch` で 2 本を同時実行した際に実際に発生した(run 28837498746)。

## 変更内容

両ワークフローの「Commit and push」ステップで、`git push origin HEAD:main` の直前に以下を追加する。

```sh
git fetch origin main
git rebase FETCH_HEAD
```

`git pull --rebase` ではなく fetch + rebase を明示するのは、`actions/checkout` の detached HEAD / shallow clone でも確実に動かすため。rebase が衝突した場合は job が失敗して止まる(両ワークフローは別ファイルを触るため通常は衝突しない)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)