### PR TITLE
fix: git の worktree.useRelativePaths を無効化

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -33,8 +33,6 @@
 	autoSetupRemote = true
 [init]
 	defaultBranch = main
-[worktree]
-	useRelativePaths = true
 [alias]
 	s = status
 	b = branch


### PR DESCRIPTION
## 概要

`deno task switch`(`nix profile upgrade --all --impure`)が以下のエラーで失敗する問題の再発防止。

```
error: opening Git repository "...": unsupported extension name extensions.relativeworktrees (libgit2 error code = 6)
```

## 原因

- `.config/git/config` の `worktree.useRelativePaths = true`(git 2.48+)が有効だと、`git worktree add` 時に gitdir リンクが相対パスで書かれ、リポジトリの local config に `extensions.relativeWorktrees = true` が自動設定される。
- Determinate Nix の git fetcher は libgit2 を使うが、libgit2 はこの extension を実装していないため、未知の extension としてリポジトリを開くこと自体を拒否する。
- このリポジトリの flake(`path:.config/nix`)は `git+file://` として読まれるため、worktree を 1 つ作った時点で `deno task switch` が失敗するようになる。

## 変更内容

`worktree.useRelativePaths` を削除する。相対リンクの利点(リポジトリ移動時に worktree が追従する)よりも、nix が使えなくなる実害が大きい。

既存リポジトリに残った相対リンクと extension の除去は、設定変更とは独立にローカルで実施する(`git -c worktree.useRelativePaths=false worktree repair` → `git config --local --unset extensions.relativeworktrees`)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)